### PR TITLE
Add ProcessWire Namespace to avoid FileCompiler troubles

### DIFF
--- a/LimitTable.module.php
+++ b/LimitTable.module.php
@@ -1,4 +1,4 @@
-<?php
+<?php namespace ProcessWire;
 
 /**
  *
@@ -23,12 +23,16 @@ class LimitTable extends WireData implements Module, ConfigurableModule {
 	public static function getModuleInfo() {
 		return array(
 			'title' => 'Limit Table',
+			'class' => 'LimitTable',
 			'version' => '0.1.2',
 			'summary' => 'Allows limits and restrictions to be placed on selected Table fields.',
 			'author' => 'Robin Sallis',
 			'href' => 'https://github.com/Toutouwai/LimitTable',
 			'icon' => 'table',
 			'autoload' => 'template=admin',
+			'requires' => [
+				'ProcessWire>=3.0'
+			]
 		);
 	}
 

--- a/LimitTable.module.php
+++ b/LimitTable.module.php
@@ -24,7 +24,7 @@ class LimitTable extends WireData implements Module, ConfigurableModule {
 		return array(
 			'title' => 'Limit Table',
 			'class' => 'LimitTable',
-			'version' => '0.1.2',
+			'version' => '0.2.0',
 			'summary' => 'Allows limits and restrictions to be placed on selected Table fields.',
 			'author' => 'Robin Sallis',
 			'href' => 'https://github.com/Toutouwai/LimitTable',


### PR DESCRIPTION
I have some FileCompiler troubles... (compiling needs sometimes > 1.5 minutes).
I guess we can add the processwire namespace here and make it only PW > 3.0 compatible to avoid the filecompiler