### PR TITLE
Add support for table fields with nested tables

### DIFF
--- a/LimitTable.js
+++ b/LimitTable.js
@@ -1,5 +1,5 @@
 function checkTable(role_class, inputfield_class, limit, show_all_rows) {
-	var $table_rows = $('body' + role_class + ' ' + inputfield_class + ' tbody tr').not('.InputfieldTableRowTemplate');
+	var $table_rows = $('body' + role_class + ' ' + inputfield_class + ' table:not(.InputfieldTableNested) > tbody > tr').not('.InputfieldTableRowTemplate');
 	var $add_button = $('body' + role_class + ' ' + inputfield_class + ' .InputfieldTableAddRow');
 	var count = $table_rows.length;
 	if(count >= limit) {

--- a/LimitTable.module
+++ b/LimitTable.module
@@ -8,7 +8,7 @@ class LimitTable extends WireData implements Module, ConfigurableModule {
 	public static function getModuleInfo() {
 		return array(
 			'title' => 'Limit Table',
-			'version' => '0.1.3',
+			'version' => '0.1.4',
 			'summary' => 'Allows limits and restrictions to be placed on selected Table fields.',
 			'author' => 'Robin Sallis',
 			'href' => 'https://github.com/Toutouwai/LimitTable',


### PR DESCRIPTION
In case a table has nested tables, which happens when total width of fields is more than 100%, the module was counting rows from them as well. This commit fixes that and doesn't, at least in my test setup, seem to cause any unexpected side effects.