### PR TITLE
Hide row num for nested tables when dragging is disabled and only one row is displayed

### DIFF
--- a/LimitTable.js
+++ b/LimitTable.js
@@ -1,5 +1,5 @@
 function checkTable(role_class, inputfield_class, limit, show_all_rows) {
-	var $table_rows = $('body' + role_class + ' ' + inputfield_class + ' tbody tr').not('.InputfieldTableRowTemplate');
+	var $table_rows = $('body' + role_class + ' ' + inputfield_class + ' table:not(.InputfieldTableNested) > tbody > tr').not('.InputfieldTableRowTemplate');
 	var $add_button = $('body' + role_class + ' ' + inputfield_class + ' .InputfieldTableAddRow');
 	var count = $table_rows.length;
 	if(count >= limit) {

--- a/LimitTable.module
+++ b/LimitTable.module
@@ -8,7 +8,7 @@ class LimitTable extends WireData implements Module, ConfigurableModule {
 	public static function getModuleInfo() {
 		return array(
 			'title' => 'Limit Table',
-			'version' => '0.1.4',
+			'version' => '0.1.5',
 			'summary' => 'Allows limits and restrictions to be placed on selected Table fields.',
 			'author' => 'Robin Sallis',
 			'href' => 'https://github.com/Toutouwai/LimitTable',
@@ -92,6 +92,7 @@ class LimitTable extends WireData implements Module, ConfigurableModule {
 				$role_class = $role === 'role-all' ? '' : ".$role";
 				$prefix = "body$role_class .Inputfield_{$if_name}";
 				if($cfg["nodrag_{$unique}"]) $css .= "$prefix .InputfieldTableRowSortHandle, ";
+				if($cfg["nodrag_{$unique}"] && $cfg["limit_{$unique}"] == 1) $css .= "$prefix .InputfieldTableActionSort, ";
 				if($cfg["notrash_{$unique}"]) $css .= "$prefix .InputfieldTableRowDeleteLink, ";
 				$css = rtrim($css, ', ');
 				if($css) $css .= " { display:none !important; }" ;

--- a/LimitTable.module
+++ b/LimitTable.module
@@ -8,7 +8,7 @@ class LimitTable extends WireData implements Module, ConfigurableModule {
 	public static function getModuleInfo() {
 		return array(
 			'title' => 'Limit Table',
-			'version' => '0.1.3',
+			'version' => '0.1.4',
 			'summary' => 'Allows limits and restrictions to be placed on selected Table fields.',
 			'author' => 'Robin Sallis',
 			'href' => 'https://github.com/Toutouwai/LimitTable',

--- a/LimitTable.module
+++ b/LimitTable.module
@@ -92,7 +92,7 @@ class LimitTable extends WireData implements Module, ConfigurableModule {
 				$role_class = $role === 'role-all' ? '' : ".$role";
 				$prefix = "body$role_class .Inputfield_{$if_name}";
 				if($cfg["nodrag_{$unique}"]) $css .= "$prefix .InputfieldTableRowSortHandle, ";
-				if($cfg["nodrag_{$unique}"] && $cfg["limit_{$unique}"] == 1) $css .= "$prefix .InputfieldTableActionSort, ";
+				if($cfg["nodrag_{$unique}"] && $cfg["limit_{$unique}"] == 1 && !$cfg["showall_{$unique}"]) $css .= "$prefix .InputfieldTableActionSort, ";
 				if($cfg["notrash_{$unique}"]) $css .= "$prefix .InputfieldTableRowDeleteLink, ";
 				$css = rtrim($css, ', ');
 				if($css) $css .= " { display:none !important; }" ;


### PR DESCRIPTION
This could be a bit opinionated, but... in case of nested tables there is a separate column with drag tools and item number. It makes sense that it is displayed only for nested tables, since it's not as easy to see which rows are nested table rows, and which are actual table field rows.

... but in case dragging is disabled by this module, limit is set to 1, and "show all rows" is not enabled, it would simply be cleaner to hide the row number — which is kind of pointless (and potentially even confusing) here anyway, since it's just displaying "1", which doesn't seem to relate to anything :)

<img width="102" alt="Screenshot 2023-09-23 at 21 36 12" src="https://github.com/Toutouwai/LimitTable/assets/1252021/1b061cb7-74a3-49ab-a8a3-b512c852b658">
<img width="90" alt="Screenshot 2023-09-23 at 21 35 38" src="https://github.com/Toutouwai/LimitTable/assets/1252021/11070bb8-3f0e-4eb7-a0c2-e057ef383a1a">

_(This PR builds on top of that other one I opened a moment ago.)_