### PR TITLE
Fix issue where hiding sort column moved column labels

### DIFF
--- a/LimitTable.module
+++ b/LimitTable.module
@@ -8,7 +8,7 @@ class LimitTable extends WireData implements Module, ConfigurableModule {
 	public static function getModuleInfo() {
 		return array(
 			'title' => 'Limit Table',
-			'version' => '0.1.5',
+			'version' => '0.1.6',
 			'summary' => 'Allows limits and restrictions to be placed on selected Table fields.',
 			'author' => 'Robin Sallis',
 			'href' => 'https://github.com/Toutouwai/LimitTable',
@@ -92,7 +92,9 @@ class LimitTable extends WireData implements Module, ConfigurableModule {
 				$role_class = $role === 'role-all' ? '' : ".$role";
 				$prefix = "body$role_class .Inputfield_{$if_name}";
 				if($cfg["nodrag_{$unique}"]) $css .= "$prefix .InputfieldTableRowSortHandle, ";
-				if($cfg["nodrag_{$unique}"] && $cfg["limit_{$unique}"] == 1 && !$cfg["showall_{$unique}"]) $css .= "$prefix .InputfieldTableActionSort, ";
+				if($cfg["nodrag_{$unique}"] && $cfg["limit_{$unique}"] == 1 && !$cfg["showall_{$unique}"]) {
+					$css .= "$prefix .InputfieldTableActionSort, $prefix :not(.InputfieldTableHasNested) > thead > tr th:first-child";
+				}
 				if($cfg["notrash_{$unique}"]) $css .= "$prefix .InputfieldTableRowDeleteLink, ";
 				$css = rtrim($css, ', ');
 				if($css) $css .= " { display:none !important; }" ;


### PR DESCRIPTION
Sorry — this is a fix for a new issue caused by my previous PR. Noticed that when _not_ dealing with nested tables, column headings were "shifting" unintentionally. Should be fixed now.